### PR TITLE
Support Non-Canonical GUID Formats in `generate` and `checksum` Functions

### DIFF
--- a/cqd/open_xpd_uuid/__init__.py
+++ b/cqd/open_xpd_uuid/__init__.py
@@ -63,16 +63,23 @@ def generate(prefix: str | None = None) -> str:
 
 
 def checksum(guid: str) -> str:
-    """Generate checksum for passed "canonical" `guid`.
+    """Generate a checksum for the given valid GUID.
 
-    Checksum is a sequence of two UPPER-case alphanumeric characters that are also allowed `guid` characters.
-    For example: "JR", "CK", "00", "1F".
+    The checksum is a sequence of two uppercase alphanumeric characters derived from the GUID.
+    It ensures the integrity of the GUID and can be used for validation purposes.
 
-    `checksum('1U7XPGQ2') == '3X'`
+    Example:
+        ``checksum('1U7XPGQ2')`` returns ``'3X'``.
 
-    :param guid: guid in canonical form
-    :return: two-letter checksum
+    :param guid: The GUID in any form (e.g., with dashes, lowercase, or ambiguous characters).
+
+    :return: A two-character checksum in canonical form.
+
+    :raises ValueError: If the ``guid`` is not provided.
+    :raises GuidValidationError: If the ``guid`` is not a valid short readable GUID.
     """
+    guid = sanitize(guid)
+    validate(guid)
     result = 403
     for i in range(1, CODE_LENGTH // CHECKSUM_LENGTH + 1):
         stop = i * CHECKSUM_LENGTH

--- a/cqd/open_xpd_uuid/__init__.py
+++ b/cqd/open_xpd_uuid/__init__.py
@@ -39,17 +39,28 @@ def decode(guid: str) -> int:
 
 
 def generate(prefix: str | None = None) -> str:
-    """Generate short readable GUID.
+    """Generate a short readable GUID.
 
-    It doesn't generate guids starting with 'Z_______'.
+    The GUID is an 8-character alphanumeric string derived from a random number.
+    Optionally, a prefix can be provided to constrain the GUID to start with the sanitized prefix.
 
-    :param prefix: prefix in canonical form.
-                It forces this function to generate guids that start with the `prefix`. Cannot start with 'Z'.
-    :return: guid
+    Example:
+        ``generate()`` returns ``'1U7XPGQ2'``.
+        ``generate('CQD')`` returns ``'CQD12345'``.
+
+    :param prefix: A string to constrain the GUID to start with the sanitized prefix.
+                   The prefix can be in any form (e.g., with dashes, lowercase, or ambiguous characters).
+                   Cannot start with ``'Z'``.
+    :return: A short readable GUID in canonical form.
+
+    :raises ValueError: If the ``prefix`` starts with ``'Z'``.
+    :raises GuidValidationError: If the ``prefix`` is not a valid short readable GUID.
     """
     randint_from = 0
     randint_to = TOTAL_COMBINATIONS
     if prefix:
+        prefix = sanitize(prefix)
+        validate(prefix.rjust(CODE_LENGTH, "0"))
         if prefix.startswith("Z"):
             msg = "`prefix` must not start with 'Z'"
             raise ValueError(msg)

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -11,6 +11,7 @@ from cqd.open_xpd_uuid import checksum
         ("ZZZZZZZZ", "CF"),
         ("12345678", "X7"),
         ("EC3949XK", "04"),
+        ("ec3949-xk", "04"),
     ],
 )
 def test_checksum(guid: str, expected_checksum: str) -> None:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -46,6 +46,21 @@ def test_generate_with_prefix(monkeypatch: pytest.MonkeyPatch, numeric_id: int, 
     monkeypatch.setattr(random, "randint", mock_randint)
 
     assert generate("CQD") == short_code
+    assert generate("cqd") == short_code
+
+
+@pytest.mark.parametrize(
+    ("prefix", "starts_with"),
+    [
+        ("cqd", "CQD"),
+        ("c-q-d", "CQD"),
+        ("cqL", "CQ1"),
+        ("Coo--oo", "C0000"),
+    ],
+)
+def test_generate_with_prefix_any_format(prefix: str, starts_with: str) -> None:
+    """Test that `generate` produces the correct short code with a prefix in any format."""
+    assert generate(prefix).startswith(starts_with)
 
 
 def test_generate_with_z_prefix_is_not_allowed() -> None:


### PR DESCRIPTION
his PR introduces enhancements to the open-xpd-uuid-lib by enabling support for non-canonical GUID formats in both the `generate` and `checksum` functions.

✨ Features:
generate function now accepts prefixes in any format (canonical or non-canonical) and automatically sanitizes them.
checksum function has been updated to accept `guid` arguments in non-canonical formats without raising exceptions.
⚠️ Breaking Change:
The checksum function behavior has changed to allow non-canonical formats, which may affect consumers relying on strict format validation.

asana: [Actualize open-xpd-uuid-lib](https://app.asana.com/1/654700433662128/project/666075018299960/task/1209724563783905?focus=true)